### PR TITLE
Allow to fetch a whole collection

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,8 @@ Basic usage:
     $ ./arteget.rb http://www.arte.tv/guide/fr/040347-001/le-cerveau-et-ses-automatismes-1-2
 4) downloading in german, standard quality:
     $ ./arteget.rb --qual=sq --lang=de karambolage
+5) downloading all the broadcast of a given program:
+    $ ./arteget.rb RC-014034
 
 Notes:
 Specifying an arbitrary string instead of an URL actualy uses the search

--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Basic usage:
 2) download the latest one that is at least 5 mn, with the description
     $ ./arteget.rb -D -m 300 karambolage
 3) downloading a single video:
-    $ ./arteget.rb http://www.arte.tv/guide/fr/040347-001/le-cerveau-et-ses-automatismes-1-2
+    $ ./arteget.rb https://www.arte.tv/fr/videos/098342-009-A/karambolage/
 4) downloading in german, standard quality:
     $ ./arteget.rb --qual=sq --lang=de karambolage
 5) downloading all the broadcast of a given program:

--- a/arteget.rb
+++ b/arteget.rb
@@ -137,6 +137,12 @@ def get_videos(lang, progname, num)
           type = "teaser"
       end
 
+      # Maybe it's a collection with subcollection
+      if list['data'].empty? then
+        collections = prog_parsed.find_all {|p| p['code']['name'] == 'collection_subcollection'}
+        list['data'] = collections.map{|e| e['data']}.flatten(1)
+      end
+
       teasers = list['data'].find_all {|e| e['type'] == type}
     end
 


### PR DESCRIPTION
This patch allows to download all broadcast of a given program.

Without this patch, collections aren't handled:
```
$ arteget.rb RC-019767
Searching for RC-019767 at https://www.arte.tv/guide/api/emac/v3/fr/web/search/?query=RC-019767
Getting RC-019767 (page 1) JSON collection at https://www.arte.tv/guide/api/emac/v3/fr/web/data/COLLECTION_VIDEOS/?collectionId=RC-019767&page=1
Getting RC-019767 page at https://www.arte.tv/fr/videos/RC-019767/a-young-doctor-s-notebook/
Program id: RC-019767
```
With this patch:
```
$ arteget.rb RC-019767
Searching for RC-019767 at https://www.arte.tv/guide/api/emac/v3/fr/web/search/?query=RC-019767
Getting RC-019767 (page 1) JSON collection at https://www.arte.tv/guide/api/emac/v3/fr/web/data/COLLECTION_VIDEOS/?collectionId=RC-019767&page=1
Getting RC-019767 page at https://www.arte.tv/fr/videos/RC-019767/a-young-doctor-s-notebook/
Program id: RC-019767
Found 8 videos
Trying to get A Young Doctor's Notebook - Saison 2 (4/4)
Getting video description JSON
A Young Doctor's Notebook - Saison 2 (4/4) : Avec Daniel Radcliffe et Jon Hamm, une plongée caustique et hallucinée dans la psyché d'un jeune médecin russe en 1917. Dernier épisode : les gardes rouges déboulent à Mourievo, réveillant l’esprit de sacrifice du jeune docteur.
Dumping video : 095856-008-A_A Young Doctor's Notebook - Saison 2 (4 4)_sq.mp4
2021-03-03 17:40:58 URL:https://arteptweb-a.akamaihd.net/am/ptweb/095000/095800/095856-008-A_SQ_0_VO-STF_05255124_MP4-2200_AMM-PTWEB_1PTwn10sigt.mp4 [403183930/403183930] -> "095856-008-A_A Young Doctor's Notebook - Saison 2 (4 4)_sq.mp4" [1]
Video successfully dumped

Trying to get A Young Doctor's Notebook - Saison 2 (3/4)
Getting video description JSON
A Young Doctor's Notebook - Saison 2 (3/4) : Avec Daniel Radcliffe et Jon Hamm, une plongée caustique et hallucinée dans la psyché d'un jeune médecin russe en 1917. Dans cet épisode : indifférent aux souffrances de son ancienne maîtresse, le jeune docteur n’écoute que les battements de son propre cœur.
Dumping video : 095856-007-A_A Young Doctor's Notebook - Saison 2 (3 4)_sq.mp4
2021-03-03 17:41:40 URL:https://arteptweb-a.akamaihd.net/am/ptweb/095000/095800/095856-007-A_SQ_0_VO-STF_05254774_MP4-2200_AMM-PTWEB_1PTmi10sgLh.mp4 [395302086/395302086] -> "095856-007-A_A Young Doctor's Notebook - Saison 2 (3 4)_sq.mp4" [1]
Video successfully dumped
[...]
```