### PR TITLE
Fix a typo: undefined local variable or method `h'

### DIFF
--- a/arteget.rb
+++ b/arteget.rb
@@ -270,7 +270,7 @@ def dump_video(vidinfo)
     streams = vid_json['data']['attributes']["streams"]
 
     if $options[:variant] then
-        good = streams.find_all do |v|
+        good = streams.find_all do |h|
             h['mainQuality']['code'] =~ /^#{$options[:qual]}/i and
             $options[:variant] == h['versions'][0]['eStat']['ml5']
         end


### PR DESCRIPTION
Fix a typo: ```undefined local variable or method `h'```

    arteget/arteget.rb:275:in `block in dump_video': undefined local variable or method `h' for main:Object (NameError)
        from arteget/arteget.rb:273:in `each'
        from arteget/arteget.rb:273:in `find_all'
        from arteget/arteget.rb:273:in `dump_video'
        from arteget/arteget.rb:424:in `block in <main>'
        from arteget/arteget.rb:422:in `each'
        from arteget/arteget.rb:422:in `<main>'